### PR TITLE
feat: 세션 아이디를 request header로도 보내 인증하도록 추가

### DIFF
--- a/server/src/main/java/sunflower/server/api/MemberApiController.java
+++ b/server/src/main/java/sunflower/server/api/MemberApiController.java
@@ -35,14 +35,8 @@ public class MemberApiController implements MemberApiControllerDocs {
         final Long id = memberService.login(request.getLoginId(), request.getPassword());
         final String sessionId = sessionService.createSessionId(id);
 
-//        Cookie cookie = new Cookie("sessionId", sessionId);
-//        cookie.setHttpOnly(true);
-//        cookie.setMaxAge(3600);
-//        cookie.setPath("/");
-//        cookie.setSecure(true);
-//        response.addCookie(cookie);
-
-        response.setHeader("Set-Cookie", "sessionId=" + sessionId + "; HttpOnly; Max-Age=3600; Path=/; Secure; SameSite=None");
+        response.setHeader("Set-Cookie", "sessionId=" + sessionId + "; HttpOnly; Max-Age=3600; Path=/; Secure; SameSite=None"); // 사용중이지 않음
+        response.setHeader("SessionId", sessionId); // 임시 사용중
 
         return ResponseEntity
                 .status(HttpStatus.OK.value())

--- a/server/src/main/java/sunflower/server/application/resolver/MemberAuthArgumentResolver.java
+++ b/server/src/main/java/sunflower/server/application/resolver/MemberAuthArgumentResolver.java
@@ -30,7 +30,7 @@ public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer, final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String encryptedSessionId = extractSessionId(request.getCookies());
+        String encryptedSessionId = findEncryptedSessionId(request);
 
         if (encryptedSessionId == null) {
             throw new AuthException();
@@ -44,6 +44,15 @@ public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver
         } else {
             throw new AuthException();
         }
+    }
+
+    private String findEncryptedSessionId(final HttpServletRequest request) {
+        final String sessionId = request.getHeader("SessionId");
+        if (sessionId != null) {
+            return sessionId;
+        }
+
+        return extractSessionId(request.getCookies());
     }
 
     private String extractSessionId(final Cookie[] cookies) {


### PR DESCRIPTION
## 주요 변경사항

- 크롬 서버에서 쿠키를 저장하지 않는 이슈가 발생해서 임시로 request header를 통한 인증 로직을 추가하겠습니다!
- 이후 쿠키로 인증이 성공하게 된다면 해당 로직은 제거해야 합니다

## 관련 이슈

closes #

#### ✔️ Squash & Merge 방식으로 병합해 주세요!
