### PR TITLE
fix: logout 에러 수정

### DIFF
--- a/server/src/main/java/sunflower/server/application/SessionService.java
+++ b/server/src/main/java/sunflower/server/application/SessionService.java
@@ -38,7 +38,7 @@ public class SessionService {
 
     @Transactional
     public void logout(final Long memberId) {
-        final Session session = sessionRepository.getByMemberId(memberId);
+        final Session session = sessionRepository.getByMemberIdAndIsLoggedInTrue(memberId);
         session.logout();
     }
 }

--- a/server/src/main/java/sunflower/server/entity/Session.java
+++ b/server/src/main/java/sunflower/server/entity/Session.java
@@ -26,6 +26,7 @@ public class Session {
     private Long memberId;
     private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
+    private Boolean isLoggedIn = Boolean.TRUE;
     private Boolean deleted = Boolean.FALSE;
 
     public Session(final Long memberId) {
@@ -43,7 +44,7 @@ public class Session {
     }
 
     public boolean isValid() {
-        if (this.deleted == Boolean.TRUE) {
+        if (!this.isLoggedIn) {
             return false;
         }
         // TODO: 현재는 만료 시간만 체크중이지만, 이후에 IP 등 다양한 검증 로직 추가
@@ -57,6 +58,6 @@ public class Session {
     }
 
     public void logout() {
-        this.deleted = Boolean.TRUE;
+        this.isLoggedIn = Boolean.FALSE;
     }
 }

--- a/server/src/main/java/sunflower/server/repository/SessionRepository.java
+++ b/server/src/main/java/sunflower/server/repository/SessionRepository.java
@@ -16,13 +16,15 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
         return session.get();
     }
 
-    default Session getByMemberId(final Long memberId) {
-        final Optional<Session> session = findByMemberId(memberId);
+    default Session getByMemberIdAndIsLoggedInTrue(final Long memberId) {
+        final Optional<Session> session = findByMemberIdAndIsLoggedInTrue(memberId);
         if (session.isEmpty()) {
             new AuthException();
         }
         return session.get();
     }
 
-    Optional<Session> findByMemberId(Long memberId);
+    Optional<Session> findByMemberId(final Long memberId);
+
+    Optional<Session> findByMemberIdAndIsLoggedInTrue(final Long memberId);
 }


### PR DESCRIPTION
## 주요 변경사항

- 로그아웃 시에 isLoggedIn을 FALSE로 바꾸는 로직을 추가하면서, 이후에 세션이 유효한지 찾을 때 isLoggedIn이 TRUE인 것중에 찾도록 해야하는데 깜빡해서 자꾸 2개 이상의 결과를 반환하는 에러가 나고 있었습니다! 수정 완료 cc. @JunhyeongPark-kr 

## 관련 이슈

closes #

#### ✔️ Squash & Merge 방식으로 병합해 주세요!
