### PR TITLE
feat: 점역 결과 이름 변경 API 구현

### DIFF
--- a/server/src/main/java/sunflower/server/api/TranscriptionApiController.java
+++ b/server/src/main/java/sunflower/server/api/TranscriptionApiController.java
@@ -5,10 +5,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import sunflower.server.api.request.TranscriptionNameUpdateRequest;
 import sunflower.server.api.response.BrfFileQueryResponse;
 import sunflower.server.api.response.PdfRegisterResponse;
 import sunflower.server.api.response.TranscriptionStatusResponse;
@@ -63,5 +65,15 @@ public class TranscriptionApiController implements TranscriptionApiControllerDoc
         final BrfFileDto brfFile = transcriptionService.findBrfFileById(id);
         final BrfFileQueryResponse response = BrfFileQueryResponse.from(id, brfFile.getOriginalFileName(), brfFile.getContent());
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/name")
+    public ResponseEntity<Void> updateFileName(
+            MemberAuth member,
+            @PathVariable("id") Long id,
+            @RequestBody TranscriptionNameUpdateRequest request
+    ) {
+        transcriptionService.updateFileName(member.getId(), request.getName());
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/sunflower/server/api/TranscriptionApiControllerDocs.java
+++ b/server/src/main/java/sunflower/server/api/TranscriptionApiControllerDocs.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import sunflower.server.api.request.TranscriptionNameUpdateRequest;
 import sunflower.server.api.response.BrfFileQueryResponse;
 import sunflower.server.api.response.PdfRegisterResponse;
 import sunflower.server.api.response.TranscriptionStatusResponse;
@@ -52,5 +54,13 @@ public interface TranscriptionApiControllerDocs {
     ResponseEntity<BrfFileQueryResponse> queryBrfFile(
             MemberAuth member,
             @Parameter(description = "Transcriptions id", required = true) @PathVariable("id") Long id
+    );
+
+    @Operation(summary = "점역 이름 변경 API", description = "점역된 결과에 대해 직접 이름을 설정합니다. (인증 정보는 쿠키를 통해서 받습니다.)")
+    @ApiResponse(responseCode = "200", description = "이름 변경이 완료되었습니다.")
+    ResponseEntity<Void> updateFileName(
+            MemberAuth member,
+            @PathVariable("id") Long id,
+            @RequestBody TranscriptionNameUpdateRequest request
     );
 }

--- a/server/src/main/java/sunflower/server/api/request/TranscriptionNameUpdateRequest.java
+++ b/server/src/main/java/sunflower/server/api/request/TranscriptionNameUpdateRequest.java
@@ -1,0 +1,16 @@
+package sunflower.server.api.request;
+
+import lombok.Getter;
+
+@Getter
+public class TranscriptionNameUpdateRequest {
+
+    private String name;
+
+    public TranscriptionNameUpdateRequest() {
+    }
+
+    public TranscriptionNameUpdateRequest(final String name) {
+        this.name = name;
+    }
+}

--- a/server/src/main/java/sunflower/server/application/TranscriptionService.java
+++ b/server/src/main/java/sunflower/server/application/TranscriptionService.java
@@ -59,4 +59,10 @@ public class TranscriptionService {
         final String content = FileUtil.readFile(file);
         return BrfFileDto.of(transcriptions, content);
     }
+
+    @Transactional
+    public void updateFileName(final Long id, final String name) {
+        final Transcriptions transcriptions = transcriptionsRepository.getById(id);
+        transcriptions.changeName(name);
+    }
 }

--- a/server/src/main/java/sunflower/server/entity/Transcriptions.java
+++ b/server/src/main/java/sunflower/server/entity/Transcriptions.java
@@ -24,6 +24,7 @@ public class Transcriptions {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
+    private String name;
     private String inputFileName;
     private String ocrPdfId;
 
@@ -42,6 +43,7 @@ public class Transcriptions {
         transcriptions.start();
         transcriptions.changePdfPath(pdfPath);
         transcriptions.changeInputFileName(inputFileName);
+        transcriptions.changeName(inputFileName);
         return transcriptions;
     }
 
@@ -65,6 +67,10 @@ public class Transcriptions {
 
     public void registerPdfId(final String ocrPdfId) {
         this.ocrPdfId = ocrPdfId;
+    }
+
+    public void changeName(final String name) {
+        this.name = name;
     }
 
     public void changeOcrStatus(final OcrStatusDto dto) {


### PR DESCRIPTION
## 주요 변경사항

- 점역 결과에 이름을 붙이면 좋겠다는 사용자 피드백이 있어서 반영했습니다.
- 초기값은 inputFileName과 동일하게 설정했고, 이후에 해당 API 사용해서 변경할 수 있도록 열어두시면 될 것 같습니다!

<img width="1331" alt="image" src="https://github.com/sunnybraille/sunnybraille-server/assets/107979804/142a1397-cbc3-4928-8c7c-832e4fddbeff">

cc. @JunhyeongPark-kr 


## 관련 이슈

closes #117 

#### ✔️ Squash & Merge 방식으로 병합해 주세요!
