### PR TITLE
feat: 카카오 로그인 페이지로 redirect 시키기

### DIFF
--- a/server/src/main/java/sunflower/server/auth/api/KakaoMemberApiController.java
+++ b/server/src/main/java/sunflower/server/auth/api/KakaoMemberApiController.java
@@ -1,0 +1,25 @@
+package sunflower.server.auth.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sunflower.server.application.SessionService;
+import sunflower.server.auth.application.KakaoMemberService;
+
+@RequiredArgsConstructor
+@RestController
+public class KakaoMemberApiController {
+
+    private final KakaoMemberService kakaoMemberService;
+    private final SessionService sessionService;
+
+    @GetMapping("/login/kakao")
+    public ResponseEntity<Void> login() {
+        final String uri = kakaoMemberService.loginURI();
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Location", uri)
+                .build();
+    }
+}

--- a/server/src/main/java/sunflower/server/auth/api/MemberApiController.java
+++ b/server/src/main/java/sunflower/server/auth/api/MemberApiController.java
@@ -1,4 +1,4 @@
-package sunflower.server.api;
+package sunflower.server.auth.api;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import sunflower.server.api.request.JoinRequest;
 import sunflower.server.api.request.LoginRequest;
-import sunflower.server.application.MemberService;
+import sunflower.server.auth.application.MemberService;
 import sunflower.server.application.SessionService;
 import sunflower.server.application.resolver.MemberAuth;
 

--- a/server/src/main/java/sunflower/server/auth/api/MemberApiControllerDocs.java
+++ b/server/src/main/java/sunflower/server/auth/api/MemberApiControllerDocs.java
@@ -1,4 +1,4 @@
-package sunflower.server.api;
+package sunflower.server.auth.api;
 
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;

--- a/server/src/main/java/sunflower/server/auth/application/KakaoMemberService.java
+++ b/server/src/main/java/sunflower/server/auth/application/KakaoMemberService.java
@@ -1,0 +1,26 @@
+package sunflower.server.auth.application;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KakaoMemberService {
+
+    private String redirectURI;
+    private String restApiKey;
+    private String authCodeURI;
+
+    public KakaoMemberService(
+            @Value("${oauth.kakao.rest-api-key}") String restApiKey,
+            @Value("${oauth.kakao.redirect-uri}") String redirectURI,
+            @Value("${oauth.kakao.auth-code-uri}") String authCodeURI
+    ) {
+        this.redirectURI = redirectURI;
+        this.restApiKey = restApiKey;
+        this.authCodeURI = authCodeURI;
+    }
+
+    public String loginURI() {
+        return String.format(authCodeURI, restApiKey, redirectURI);
+    }
+}

--- a/server/src/main/java/sunflower/server/auth/application/MemberService.java
+++ b/server/src/main/java/sunflower/server/auth/application/MemberService.java
@@ -1,4 +1,4 @@
-package sunflower.server.application;
+package sunflower.server.auth.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -7,3 +7,9 @@ client:
 
 encryption:
   secret-key: VNaqsewrTM84zdZB+52sXOg==
+
+oauth:
+  kakao:
+    redirect-uri: https://www.sunnybraille.com/login/kakao
+    rest-api-key: rest-api-key
+    auth-code-uri: auth-code-uri


### PR DESCRIPTION
## 주요 변경사항

- `/login/kakao`로 GET 요청 보내면 아래처럼 곧바로 redirect되도록 만들었습니다.
- 한 가지 더 프로세스가 필요하므로 또 알려드릴게요!

<img width="1562" alt="image" src="https://github.com/sunnybraille/sunnybraille-server/assets/107979804/9c25208a-f738-40e4-af36-ff06c7f8e6bf">


## 관련 이슈

closes #

#### ✔️ Squash & Merge 방식으로 병합해 주세요!
